### PR TITLE
Add wrapper around core for easier SoC implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,8 +342,12 @@ hs_err_pid*
 
 
 *.bin
-*.s
+asm.s
 *.pdf
 *.v
 *.json
 *.fir
+.metals
+vivado_project
+programs/*.bin
+programs/*.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PORT := COM6
+PROGRAM := blink
+
+programs/%.out: programs/%.S
+	riscv64-unknown-elf-gcc.exe -nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -T programs/linker.ld $< -o $@
+
+programs/%.bin: programs/%.out
+	riscv64-unknown-elf-objcopy.exe -O binary $< $@
+
+comp: programs/$(PROGRAM).out programs/$(PROGRAM).bin
+
+download: comp
+	python tools/downloader.py $(PORT) $(PROGRAM)
+
+clean:
+	rm -rf programs/*.bin
+	rm -rf programs/*.elf
+	rm -rf programs/*.o
+	rm -rf programs/*.out
+	rm -rf programs/*.elf

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
 PORT := COM6
 PROGRAM := blink
 
-programs/%.out: programs/%.S
-	riscv64-unknown-elf-gcc.exe -nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -T programs/linker.ld $< -o $@
+.PRECIOUS: programs/%.elf
 
-programs/%.bin: programs/%.out
+# Need -nostdlib and -nostartfiles to run bare-metal code
+# Need march=rv32i and mabi=ilp32 to ensure only rv32i instructions are generated and correct calling conventions
+# Need linker script to correctly map data into memory
+# Need -Wl,--no-relax to remove errors when placing .text at 0x00.
+programs/%.elf: programs/%.S
+	riscv64-unknown-elf-gcc.exe -nostdlib -nostartfiles -march=rv32i -mabi=ilp32 \
+	-T programs/linker.ld -Wl,--no-relax $< -o $@
+
+programs/%.bin: programs/%.elf
 	riscv64-unknown-elf-objcopy.exe -O binary $< $@
 
-comp: programs/$(PROGRAM).out programs/$(PROGRAM).bin
+comp: programs/$(PROGRAM).elf programs/$(PROGRAM).bin
 
 download: comp
 	python tools/downloader.py $(PORT) $(PROGRAM)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PROGRAM := blink
 # Need march=rv32i and mabi=ilp32 to ensure only rv32i instructions are generated and correct calling conventions
 # Need linker script to correctly map data into memory
 # Need -Wl,--no-relax to remove errors when placing .text at 0x00.
+# Could include -Wl,--nmagic to not align .data to a page boundary (0x1000) for smaller ELF files, but that's not necessary for now
 programs/%.elf: programs/%.S
 	riscv64-unknown-elf-gcc.exe -nostdlib -nostartfiles -march=rv32i -mabi=ilp32 \
 	-T programs/linker.ld -Wl,--no-relax $< -o $@

--- a/programs/beef.S
+++ b/programs/beef.S
@@ -1,0 +1,9 @@
+.globl _start
+
+.text
+_start:
+li x1, 0xbeef
+li x2, 0x02000000
+sw x1, 0(x2)
+LOOP: addi x0, x0, 0
+j LOOP

--- a/programs/blink.S
+++ b/programs/blink.S
@@ -1,0 +1,17 @@
+.globl _start
+
+.text
+_start:
+li x1, 0        # Blink value
+li x2, 0        # Counter value
+li x3, 4000000  #Max count value
+li x4, 0x02000000
+
+LOOP: addi x2, x2, 1 #Takes 4.4cc per increment of the counter. Max count 4_000_000 = 17_200_000 cc = 1/4 of a second
+blt x2, x3, LOOP #count up
+addi x1, x1, 1
+sw x1, 0(x4)
+li x2, 0
+j LOOP
+
+

--- a/programs/bootloader.c
+++ b/programs/bootloader.c
@@ -1,0 +1,53 @@
+#include <stdint.h>
+
+#define UART_BASE  0x01000000
+#define INSTR_BASE (uint8_t*) 0x00001000
+#define prog ((void (*)(void))0x00001000)
+
+/*
+Uart functionality:
+Read data
+read data available flag
+write data
+write data buffer full flag
+*/
+typedef struct {
+  uint32_t rd_data;     //Read data word. Undefined if rd_flag is 0
+  uint32_t rd_flag;     //Read data available flag. 1 if data is available, 0 otherwise
+  uint32_t rd_buf_cnt;  //Number of data words available in read buffer
+  uint32_t not_used;
+  uint32_t wr_data;     //Write data to write buffer
+  uint32_t wr_buf_full; //Write buffer full flag. 1 if buffer is full, 0 otherwise. If data is written while full, that data is lot
+  uint32_t wr_buf_cnt;  //Number of items in write buffer
+} uart_t;
+
+/**
+General structure:
+Wait until a byte arrives. That byte encodes the number of following data bytes
+Load all of those data bytes into memory starting at INSTR_BASE
+Repeat until M != 255, then jump to INSTR_BASE
+
+https://stackoverflow.com/questions/31390127/how-can-i-compile-c-code-to-get-a-bare-metal-skeleton-of-a-minimal-risc-v-assemb#31393890
+*/
+
+void main() {
+  uint8_t num_bytes;
+  uint16_t tot_bytes;
+  uint8_t num_bytes_read;
+  volatile uart_t* uart = (uart_t*) UART_BASE;
+
+  num_bytes = 255;
+  tot_bytes = 0;
+
+  do {
+    while (!uart->rd_flag) {}; //spin
+    num_bytes = uart->rd_data;
+
+    for(num_bytes_read = 0; num_bytes_read < num_bytes; num_bytes++) {
+      *(INSTR_BASE + tot_bytes) = uart->rd_data;
+    };
+  } while(num_bytes == 255);
+  //Finished fetching: Jump to INSTR_BASE
+  prog();
+
+}

--- a/programs/hello.S
+++ b/programs/hello.S
@@ -1,0 +1,32 @@
+.equ UART_BASE,    0x01000000
+.equ UART_TX,      0x01000010
+.equ UART_TX_FULL, 0x01000014
+.globl _start
+
+.text
+_start:
+la x1, HELLO_WORLD
+lb x2, 0(x1) #Initial fetch to simplify loop
+lui x3, %hi(UART_TX)
+addi x3, x3, %lo(UART_TX)      #x3 = UART_TX
+lui x4, %hi(UART_TX_FULL)
+addi x4, x4, %lo(UART_TX_FULL) # x4 = UART_TX_FULL
+ECHO:
+beqz x2, PAUSE           #End of string
+addi x1, x1, 1          #incr char index
+CHECK_TX_FULL:
+lw x5, (x4)     #check if buffer is full
+bnez x5, CHECK_TX_FULL
+sb x2, (x3)          #write to UART
+lbu x2, 0(x1)        #Fetch new value
+j ECHO
+PAUSE: #end of string. Count up before going back
+li x1, 0
+li x2, 8000000
+PAUSE_LOOP: addi x1, x1, 1
+blt x1, x2, PAUSE_LOOP #count up
+j _start
+
+.data
+HELLO_WORLD: .string "Hello World!\n\r"
+.align(4) #Make sure a full byte is taken up

--- a/programs/linker.ld
+++ b/programs/linker.ld
@@ -1,0 +1,20 @@
+ENTRY(_start)
+
+MEMORY
+{
+  INST (rx)  : ORIGIN = 0x0,   LENGTH = 0x100
+  DATA (rwx) : ORIGIN = 0x100, LENGTH = 0x100
+}
+
+SECTIONS
+{
+  .data :
+  {
+    *(.data)
+  }> DATA
+
+  .text :
+  {
+    *(.text)
+  }> INST
+}

--- a/programs/linker.ld
+++ b/programs/linker.ld
@@ -1,20 +1,22 @@
 ENTRY(_start)
+OUTPUT_FORMAT(elf32-littleriscv)
 
-MEMORY
-{
-  INST (rx)  : ORIGIN = 0x0,   LENGTH = 0x100
-  DATA (rwx) : ORIGIN = 0x100, LENGTH = 0x100
+MEMORY {
+  ONCHIP (rwx) : ORIGIN = 0x0, LENGTH = 0x100 /*Length 0x100 is just a guess for now */
 }
 
 SECTIONS
 {
+  .text : {
+    * (.text)
+  }
+
   .data :
   {
     *(.data)
-  }> DATA
+  }
 
-  .text :
-  {
-    *(.text)
-  }> INST
+  /DISCARD/ : {
+    *(.note.gnu.build-id) /*Generated with riscv64-linux-gnu-gcc, not with unknown-elf */
+  }
 }

--- a/programs/linker.ld
+++ b/programs/linker.ld
@@ -1,10 +1,6 @@
 ENTRY(_start)
 OUTPUT_FORMAT(elf32-littleriscv)
 
-MEMORY {
-  ONCHIP (rwx) : ORIGIN = 0x0, LENGTH = 0x100 /*Length 0x100 is just a guess for now */
-}
-
 SECTIONS
 {
   .text : {
@@ -17,6 +13,6 @@ SECTIONS
   }
 
   /DISCARD/ : {
-    *(.note.gnu.build-id) /*Generated with riscv64-linux-gnu-gcc, not with unknown-elf */
+    *(*) /*We don't want .note.gnu.build-id generated when using linux-gnu-gcc */
   }
 }

--- a/src/main/scala/Top.scala
+++ b/src/main/scala/Top.scala
@@ -6,10 +6,10 @@ import scala.collection.immutable.HashMap
 
 object Top extends App {
   val wrapConf = scala.collection.immutable.HashMap(
-    "numKeys" -> 16,
-    "numLeds" -> 16,
-    "uartFreq" -> 100_000_000,
-    "uartBaud" -> 9600,
+    "numKeys" -> 12,
+    "numLeds" -> 12,
+    "coreFreq" -> 80_000_000,
+    "uartBaud" -> 115200,
     "uartRxBufSize" -> 2,
     "uartTxBufSize" -> 2,
     "uartBaseAddr" -> 0x01,
@@ -18,5 +18,4 @@ object Top extends App {
     "memSize" -> 2048
   )
   chisel3.emitVerilog(new CoreWrapper(wrapConf)(Config()))
-//  chisel3.emitVerilog(new HWBootloader(4, 2, 1, 1)(Config()))
 }

--- a/src/main/scala/Top.scala
+++ b/src/main/scala/Top.scala
@@ -1,6 +1,22 @@
 import chisel3._
 import core._
+import peripherals._
+
+import scala.collection.immutable.HashMap
 
 object Top extends App {
-  chisel3.emitVerilog(new Core()(Config()))
+  val wrapConf = scala.collection.immutable.HashMap(
+    "numKeys" -> 16,
+    "numLeds" -> 16,
+    "uartFreq" -> 100_000_000,
+    "uartBaud" -> 9600,
+    "uartRxBufSize" -> 2,
+    "uartTxBufSize" -> 2,
+    "uartBaseAddr" -> 0x01,
+    "ledsBaseAddr" -> 0x02,
+    "keysBaseAddr" -> 0x03,
+    "memSize" -> 2048
+  )
+  chisel3.emitVerilog(new CoreWrapper(wrapConf)(Config()))
+//  chisel3.emitVerilog(new HWBootloader(4, 2, 1, 1)(Config()))
 }

--- a/src/main/scala/core/Core.scala
+++ b/src/main/scala/core/Core.scala
@@ -33,8 +33,8 @@ class Core(implicit conf: Config) extends Module {
 
   //Memory connections
   io.imem <> fetch.io.mem
-  io.dmem.out <> execute.io.mem
-  io.dmem.in <> memory.io.mem
+  io.dmem.req <> execute.io.mem
+  io.dmem.resp <> memory.io.mem
 
   //Control signals and hazard detection
   fetch.io.ctrl.loadPC := execute.io.fetch.loadPC

--- a/src/main/scala/core/CoreWrapper.scala
+++ b/src/main/scala/core/CoreWrapper.scala
@@ -1,0 +1,70 @@
+package core
+import chisel3._
+import chisel3.util.switch
+import peripherals.{HWBootloader, Keys, Leds, MemArbiter, MemBlock, MemMux, Uart, UartWrapper}
+
+/**
+ * A wrapper around the core, wrapping a UART interface and an interface to some switches and LEDs on an FPGA board
+ * @param wrapConf
+ * @param conf
+ */
+class CoreWrapper(wrapConf: Map[String,Int])(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val uart = new Bundle {
+      val tx = Output(Bool())
+      val rx = Input(Bool())
+    }
+    val keys = Input(UInt(wrapConf("numKeys").W))
+    val leds = Output(UInt(wrapConf("numLeds").W))
+  })
+
+  //Modules
+  val core = Module(new Core)
+  val memblock = Module(new MemBlock(wrapConf("memSize")))
+  val uart = Module(new UartWrapper(
+    wrapConf("uartFreq"),
+    wrapConf("uartBaud"),
+    wrapConf("uartRxBufSize"),
+    wrapConf("uartTxBufSize"))
+  )
+  val keys = Module(new Keys(wrapConf("numKeys")))
+  val leds = Module(new Leds(wrapConf("numLeds")))
+  val memArb = Module(new MemArbiter(4, Seq(0x00, wrapConf("uartBaseAddr"), wrapConf("keysBaseAddr"), wrapConf("ledsBaseAddr"))))
+  val memMux = Module(new MemMux)
+  //Bad implementation right now, but we do what works. Duplicate UART for bootloader and core
+  val bootloader = Module(new HWBootloader(wrapConf("uartFreq"), wrapConf("uartBaud"), 2, 2))
+
+  //When !go, hwbootloader should write directly into memblock. When go, memblock should be connected to memMux instead
+  when(!bootloader.io.go) {
+    memblock.io <> bootloader.io.mem
+    memMux.io.mem.resp.ack := false.B
+    memMux.io.mem.resp.rdata := 0.U
+  } .otherwise {
+    memblock.io <> memMux.io.mem
+    bootloader.io.mem.resp.ack := false.B
+    bootloader.io.mem.resp.rdata := 0.U
+  }
+
+  memMux.io.imem <> core.io.imem
+
+  memArb.io.master <> core.io.dmem
+  memArb.io.periph(0) <> memMux.io.dmem
+  memArb.io.periph(1) <> uart.io.mem
+  memArb.io.periph(2) <> keys.io.mem
+  memArb.io.periph(3) <> leds.io.mem
+
+  //Connect to world
+  uart.io.rxd := io.uart.rx
+  bootloader.io.rxd := io.uart.rx
+  io.uart.tx := uart.io.txd
+  io.leds := leds.io.leds
+  keys.io.keys := io.keys
+}
+
+case class WrapperConfig(
+                        uartAddr: Int,
+                        keysAddr: Int,
+                        numKeys: Int,
+                        ledsAddr: Int,
+                        numLeds: Int
+                        )

--- a/src/main/scala/core/Interfaces.scala
+++ b/src/main/scala/core/Interfaces.scala
@@ -139,8 +139,8 @@ class MemoryResponse(implicit conf: Config) extends Bundle {
  * @param conf
  */
 class MemoryInterface(implicit conf: Config) extends Bundle {
-  val out = Output(new MemoryRequest)
-  val in = Input(new MemoryResponse)
+  val req = Output(new MemoryRequest)
+  val resp = Input(new MemoryResponse)
 }
 
 /**

--- a/src/main/scala/peripherals/HWBootloader.scala
+++ b/src/main/scala/peripherals/HWBootloader.scala
@@ -10,8 +10,7 @@ class HWBootloader(val frequency: Int,
                    rxBufSize: Int,
                    txBufSize: Int)(implicit conf: Config) extends Module {
   val io = IO(new Bundle {
-    val memIn = Input(new MemoryResponse)
-    val memOut = Output(new MemoryRequest)
+    val mem = new MemoryInterface
     /** UART rx data */
     val rxd = Input(Bool())
     /** GO-signal to core to start execution */
@@ -56,8 +55,7 @@ class HWBootloader(val frequency: Int,
       }
     }
     is(LOOP2) { //Store byte in memory
-      //req high -> set below
-      when(io.memIn.ack) {
+      when(io.mem.resp.ack) {
         state := LOOP3
       }
     }
@@ -69,11 +67,11 @@ class HWBootloader(val frequency: Int,
     }
   }
 
-  io.memOut.wmask := wmask
-  io.memOut.addr := 0.U(16.W) ## addr ## 0.U(2.W)
-  io.memOut.wdata := Fill(4, byte)
-  io.memOut.we := true.B
-  io.memOut.req := state === LOOP2 && !io.memIn.ack
+  io.mem.req.wmask := wmask
+  io.mem.req.addr := 0.U(16.W) ## addr ## 0.U(2.W)
+  io.mem.req.wdata := Fill(4, byte)
+  io.mem.req.we := true.B
+  io.mem.req.req := state === LOOP2 && !io.mem.resp.ack
   io.go := state === GO
 
 

--- a/src/main/scala/peripherals/HWBootloader.scala
+++ b/src/main/scala/peripherals/HWBootloader.scala
@@ -1,0 +1,83 @@
+package peripherals
+
+import chisel3._
+import chisel3.util._
+import core._
+import peripherals.HWBootloaderState._
+
+class HWBootloader(val frequency: Int,
+                   val baudRate: Int,
+                   rxBufSize: Int,
+                   txBufSize: Int)(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val memIn = Input(new MemoryResponse)
+    val memOut = Output(new MemoryRequest)
+    /** UART rx data */
+    val rxd = Input(Bool())
+    /** GO-signal to core to start execution */
+    val go = Output(Bool())
+  })
+  //Modules
+  val uart = Module(new Uart(frequency, baudRate, rxBufSize, txBufSize))
+
+  //Registers
+  val go = RegInit(false.B)
+  val state = RegInit(IDLE)
+  val cnt = RegInit(0.U(8.W)) //num bytes received this loop
+  val numBytesInTx = RegInit(0.U(8.W)) //total number of bytes in this loop
+  val wmask = RegInit(1.U(4.W))
+  val addr = RegInit(0.U(14.W))
+  val byte = RegInit(0.U(8.W))
+
+  //Signals, default assignments
+  val isLastPacket = !numBytesInTx.andR //If numBytesInTx is 255, not the last packet. If not and andR is 0, is last packet
+  uart.io.rdData.ready := false.B
+  uart.io.rxd := io.rxd
+
+  //State handling
+  switch(state) {
+    is(IDLE) {
+      when(uart.io.rxAvail) {
+        state := LOOP1
+        uart.io.rdData.ready := true.B
+        numBytesInTx := uart.io.rdData.bits
+        cnt := 0.U
+      }
+    }
+    is(LOOP1) { //Wait for new byte, or exit loop if finished
+      when(cnt === numBytesInTx && isLastPacket) {
+        state := GO
+      } .elsewhen(cnt === numBytesInTx && !isLastPacket) {
+        state := IDLE
+      } .elsewhen(uart.io.rxAvail) {
+        state := LOOP2
+        byte := uart.io.rdData.bits
+        uart.io.rdData.ready := true.B
+      }
+    }
+    is(LOOP2) { //Store byte in memory
+      //req high -> set below
+      when(io.memIn.ack) {
+        state := LOOP3
+      }
+    }
+    is(LOOP3) {
+      state := LOOP1
+      addr := Mux(wmask(3), addr + 1.U, addr) //Full instruction has been written, go to next instruction
+      wmask := wmask(2,0) ## wmask(3)
+      cnt := cnt + 1.U
+    }
+  }
+
+  io.memOut.wmask := wmask
+  io.memOut.addr := 0.U(16.W) ## addr ## 0.U(2.W)
+  io.memOut.wdata := Fill(4, byte)
+  io.memOut.we := true.B
+  io.memOut.req := state === LOOP2 && !io.memIn.ack
+  io.go := state === GO
+
+
+  uart.io.txData.bits := DontCare
+  uart.io.txData.valid := false.B
+
+}

--- a/src/main/scala/peripherals/HWBootloaderState.scala
+++ b/src/main/scala/peripherals/HWBootloaderState.scala
@@ -1,0 +1,7 @@
+package peripherals
+
+import chisel3.experimental.ChiselEnum
+
+object HWBootloaderState extends ChiselEnum {
+  val IDLE, LOOP1, LOOP2, LOOP3, GO = Value
+}

--- a/src/main/scala/peripherals/Keys.scala
+++ b/src/main/scala/peripherals/Keys.scala
@@ -1,0 +1,15 @@
+package peripherals
+
+import chisel3._
+import core.{Config, MemoryInterface, MemoryRequest, MemoryResponse}
+
+class Keys(numKeys: Int)(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val mem = Flipped(new MemoryInterface)
+    val keys = Input(UInt(numKeys.W))
+  })
+
+  io.mem.resp.rdata := RegNext(RegNext(io.keys)) //Double-registering to synchronize. TODO, probably also needs debouncing
+  io.mem.resp.ack := RegNext(io.mem.req.req)
+
+}

--- a/src/main/scala/peripherals/Leds.scala
+++ b/src/main/scala/peripherals/Leds.scala
@@ -1,0 +1,30 @@
+package peripherals
+
+import chisel3._
+import core.{Config, MemoryInterface, MemoryRequest, MemoryResponse}
+
+class Leds(numLeds: Int)(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val mem = Flipped(new MemoryInterface)
+    val leds = Output(UInt(numLeds.W))
+  })
+  require(numLeds > 0 && numLeds <= conf.XLEN, s"Must numLeds>0 but <=${conf.XLEN}, was $numLeds")
+  //Each bit set high in the input is used to set an LED
+  val leds = RegInit(0.U(numLeds.W))
+  val rdData = RegInit(0.U(conf.XLEN.W))
+  val ack = RegNext(io.mem.req.req)
+
+
+  //Handle reads
+  when(io.mem.req.req && !io.mem.req.we) {
+    rdData := leds
+  }
+  when(io.mem.req.req && io.mem.req.we) {
+    leds := io.mem.req.wdata(numLeds-1, 0)
+  }
+
+  //Handle I/O
+  io.mem.resp.ack := ack
+  io.mem.resp.rdata := rdData
+  io.leds := leds
+}

--- a/src/main/scala/peripherals/MemArbiter.scala
+++ b/src/main/scala/peripherals/MemArbiter.scala
@@ -1,0 +1,48 @@
+package peripherals
+
+import chisel3._
+import core._
+
+/**
+ * The memory arbiter is used to arbitrate between the Core master and a number of 
+ * peripherals connected to it. 
+ * @param N The number of peripherals connected to the memory arbiter
+ * @param baseAddresses The base addresses of the connected peripherals. Used to activate and route the data signals
+ * @param conf
+ */
+class MemArbiter(N: Int, baseAddresses: Seq[Int])(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val master = Flipped(new MemoryInterface)
+    val periph = Vec(N, new MemoryInterface)
+  })
+  
+  //TODO: Check timing. Is it better to drive all output busses, or to 
+  // mux between inputs and 0's
+  // Remember to update tests if behavioru is changed
+  /*
+  Each peripheral should be driven when req is high and addressing is correct
+  Each peripherals response should be driven when ack && RegNext(req) && RegNext(correct addr)
+   */
+  //Default response to master should have ack low and rdata DontCare
+//  io.master.resp.ack := false.B
+  io.master.resp.getElements.foreach(_ := 0.U)
+  for((periph, baseAddr) <- io.periph zip baseAddresses) {
+    //Drive from master to peripheral when correctly addressed
+    val periphActivated = io.master.req.req && io.master.req.addr(31, 24) === baseAddr.U(8.W)
+    when(periphActivated) {
+      periph.req := io.master.req
+    } .otherwise {
+      periph.req.getElements.foreach(_ := 0.U)
+//      periph.req.req := DontCare
+//      periph.req.req := false.B
+    }
+    
+    //Drive response from peripheral to master
+    //TODO: Alternative implementation, perhaps with shorter path
+    // Take each response channel, AND with RegNext(periphActivated) for that channel.
+    // Drive response as OR of all AND'ed channels, mutex is ensured
+    when(RegNext(periphActivated)) {
+      io.master.resp := periph.resp
+    }
+  }
+}

--- a/src/main/scala/peripherals/MemBlock.scala
+++ b/src/main/scala/peripherals/MemBlock.scala
@@ -1,0 +1,27 @@
+package peripherals
+
+import chisel3._
+import chisel3.util._
+import core.{Config, MemoryInterface, MemoryRequest, MemoryResponse}
+
+/**
+ * A word-addressable, byte-writeable memory block, for use as internal memory when no off-chip memory is available
+ * @param numWords The number of full words that the memory should contain
+ * @param conf
+ */
+class MemBlock(numWords: Int)(implicit conf: Config) extends Module {
+  val io = IO(Flipped(new MemoryInterface))
+  require(isPow2(numWords), "number of words in memory must be a power of 2")
+
+  val mem = SyncReadMem(numWords, Vec(conf.WMASKLEN, UInt(8.W)))
+
+  //It's long, but it maps wdata from UInt to vec of bytes
+  val wdata = VecInit(io.req.wdata.asBools.grouped(8).map(x => VecInit(x).asUInt).toSeq)
+
+  val addr = io.req.addr(log2Ceil(numWords)-1+2, 2)
+  when(io.req.req && io.req.we) {
+    mem.write(addr, wdata, io.req.wmask.asBools)
+  }
+  io.resp.rdata := mem.read(addr).asUInt //todo check for correctness
+  io.resp.ack := RegNext(io.req.req)
+}

--- a/src/main/scala/peripherals/MemMux.scala
+++ b/src/main/scala/peripherals/MemMux.scala
@@ -1,0 +1,51 @@
+package peripherals
+
+import chisel3._
+import chisel3.util._
+import core.{Config, MemoryInterface}
+
+/**
+ * The memory mux is used to select whether the Imem or Dmem should access memory.
+ * Dmem is always prioritized, as it is assumed that it is less active than Imem
+ * @param conf
+ */
+class MemMux(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val imem = Flipped(new MemoryInterface)
+    val dmem = Flipped(new MemoryInterface)
+    val mem = new MemoryInterface
+  })
+  val sDMEM :: sIMEM :: Nil = Enum(2)
+  val state = RegInit(sDMEM)
+
+  //Default drives
+  Seq(io.dmem, io.imem).foreach {mi =>
+    mi.resp.rdata := DontCare
+    mi.resp.ack := false.B
+  }
+  io.mem.req := DontCare
+  io.mem.req.req := false.B
+
+  /*
+  When neither is active => give Imem priority for faster instruction fetch
+  If dmem is activated, give it priority to avoid pipeline stall as Imem always fetches
+ */
+  switch(state) {
+    is(sDMEM) {
+      io.mem.req := io.dmem.req
+      io.dmem.resp := io.mem.resp
+      when(io.imem.req.req && !io.dmem.req.req) {
+        io.mem.req := io.imem.req
+        state := sIMEM
+      }
+    }
+    is(sIMEM) {
+      io.mem.req := io.imem.req
+      io.imem.resp := io.mem.resp
+      when(io.dmem.req.req && (!io.imem.req.req || io.imem.resp.ack)) {
+        io.mem.req := io.dmem.req
+        state := sDMEM
+      }
+    }
+  }
+}

--- a/src/main/scala/peripherals/Uart.scala
+++ b/src/main/scala/peripherals/Uart.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright: 2014-2018, Technical University of Denmark, DTU Compute
+ * Author: Martin Schoeberl (martin@jopdesign.com)
+ * License: Simplified BSD License
+ *
+ * A UART is a serial port, also called an RS232 interface.
+ * Adapted from Martin Schoeberls original implementation
+ *
+ */
+
+package peripherals
+
+import chisel3._
+import chisel3.util._
+import core.{Config, MemoryRequest, MemoryResponse}
+
+/**
+ * This is a minimal data channel with a ready/valid handshake.
+ */
+//- start uart_channel
+//class Channel extends Bundle {
+//  val data = Input(Bits(8.W))
+//  val ready = Output(Bool())
+//  val valid = Input(Bool())
+//}
+//- end
+
+/**
+ * Transmit part of the UART.
+ * A minimal version without any additional buffering.
+ * Use an AXI like valid/ready handshake.
+ */
+//- start uart_tx
+class Tx(frequency: Int, baudRate: Int) extends Module {
+  val io = IO(new Bundle {
+    val txd = Output(Bits(1.W))
+    val channel = Flipped(Decoupled(UInt(8.W)))
+  })
+
+  val BIT_CNT = ((frequency + baudRate / 2) / baudRate - 1).asUInt
+
+  val shiftReg = RegInit(0x7ff.U) //Shift register containing data to transmit
+  val cntReg = RegInit(0.U(20.W)) //down-counter, when 0 transmits 1 bit
+  val bitsReg = RegInit(0.U(4.W)) //number of bits remaining to transmit in this packet
+
+  io.channel.ready := (cntReg === 0.U) && (bitsReg === 0.U)
+  io.txd := shiftReg(0)
+
+  when(cntReg === 0.U) {
+
+    cntReg := BIT_CNT
+    when(bitsReg =/= 0.U) {
+      val shift = shiftReg >> 1
+      shiftReg := Cat(1.U, shift(9, 0))
+      bitsReg := bitsReg - 1.U
+    }.otherwise {
+      when(io.channel.valid) {
+        // two stop bits, data, one start bit
+        shiftReg := Cat(Cat(3.U, io.channel.bits), 0.U)
+        bitsReg := 11.U
+      }.otherwise {
+        shiftReg := 0x7ff.U
+      }
+    }
+
+  }.otherwise {
+    cntReg := cntReg - 1.U
+  }
+}
+//- end
+
+/**
+ * Receive part of the UART.
+ * A minimal version without any additional buffering.
+ * Use an AXI like valid/ready handshake.
+ *
+ * The following code is inspired by Tommy's receive code at:
+ * https://github.com/tommythorn/yarvi
+ */
+//- start uart_rx
+class Rx(frequency: Int, baudRate: Int) extends Module {
+  val io = IO(new Bundle {
+    val rxd = Input(Bits(1.W))
+    val channel = Decoupled(UInt(8.W))
+  })
+
+  val BIT_CNT = ((frequency + baudRate / 2) / baudRate - 1).U
+  val START_CNT = ((3 * frequency / 2 + baudRate / 2) / baudRate - 1).U
+
+  // Sync in the asynchronous RX data
+  // Reset to 1 to not start reading after a reset
+  val rxReg = RegNext(RegNext(io.rxd, 1.U), 1.U)
+
+  val shiftReg = RegInit('A'.U(8.W))
+  val cntReg = RegInit(0.U(20.W))
+  val bitsReg = RegInit(0.U(4.W))
+  val valReg = RegInit(false.B)
+
+  when(cntReg =/= 0.U) {
+    cntReg := cntReg - 1.U
+  }.elsewhen(bitsReg =/= 0.U) {
+    cntReg := BIT_CNT
+    shiftReg := Cat(rxReg, shiftReg >> 1)
+    bitsReg := bitsReg - 1.U
+    // the last shifted in
+    when(bitsReg === 1.U) {
+      valReg := true.B
+    }
+    // wait 1.5 bits after falling edge of start
+  }.elsewhen(rxReg === 0.U) {
+    cntReg := START_CNT
+    bitsReg := 8.U
+  }
+
+  when(valReg && io.channel.ready) {
+    valReg := false.B
+  }
+
+  io.channel.bits := shiftReg
+  io.channel.valid := valReg
+}
+//- end
+
+class Uart(frequency: Int,
+           baudRate: Int,
+           rxBufSize: Int,
+           txBufSize: Int) extends Module {
+  val io = IO(new Bundle {
+    /** UART rx data */
+    val rxd = Input(Bool())
+    /** UART tx data */
+    val txd = Output(Bool())
+
+    /** First byte from read buffer */
+    val rdData = Decoupled(UInt(8.W))
+    /** Number of items in read buffer */
+    val rxCnt = Output(UInt(log2Ceil(rxBufSize+1).W))
+    /** Read buffer full flag */
+    val rxFull = Output(Bool())
+    /** Data available in RX buffer */
+    val rxAvail = Output(Bool())
+    /** Write to transmit buffer */
+    val txData = Flipped(Decoupled(UInt(8.W)))
+    /** Number of items in transmit buffer */
+    val txCnt = Output(UInt(log2Ceil(txBufSize+1).W))
+    /** Transmit buffer full flag */
+    val txFull = Output(Bool())
+  })
+  require(isPow2(rxBufSize), s"rxBufSize must be a power of two, was $rxBufSize")
+  require(isPow2(txBufSize), s"txBufSize must be a power of two, was $txBufSize")
+
+  val rx = Module(new Rx(frequency, baudRate))
+  val tx = Module(new Tx(frequency, baudRate))
+  val rxBuf = Module(new Queue(UInt(8.W), rxBufSize))
+  val txBuf = Module(new Queue(UInt(8.W), txBufSize))
+
+  io.txData <> txBuf.io.enq
+  txBuf.io.deq <> tx.io.channel
+
+  rx.io.channel <> rxBuf.io.enq
+  rxBuf.io.deq <> io.rdData
+
+  io.rxCnt := rxBuf.io.count
+  io.txCnt := txBuf.io.count
+  io.rxFull := rxBuf.io.count === rxBufSize.U
+  io.rxAvail := rxBuf.io.deq.valid
+  io.txFull := txBuf.io.count === txBufSize.U
+  io.txd := tx.io.txd
+  rx.io.rxd := io.rxd
+}
+
+class UartWrapper(frequency: Int,
+                  baudRate: Int,
+                  rxBufSize: Int,
+                  txBufSize: Int)(implicit conf: Config) extends Module {
+  val io = IO(new Bundle {
+    val memIn = Input(new MemoryRequest)
+    val memOut = Output(new MemoryResponse)
+    val txd = Output(Bool())
+    val rxd = Input(Bool())
+  })
+
+  //UART connections
+  val uart = Module(new Uart(frequency, baudRate, rxBufSize, txBufSize))
+  io.txd := uart.io.txd
+  uart.io.rxd := io.rxd
+
+  //Register read logic
+  val rdData = RegInit(0.U(8.W))
+  val ack = RegNext(io.memIn.req)
+
+  //Default assignments
+  uart.io.rdData.ready := false.B
+  uart.io.txData.valid := false.B
+  uart.io.txData.bits := io.memIn.wdata(7,0)
+
+  //Handle reads
+  when(io.memIn.req && !io.memIn.we) { //By definition, 2LSB will be 0
+    //Multiplex read register
+    switch(io.memIn.addr(4,2)) {
+      is(0.U(3.W)) { //rdData
+        uart.io.rdData.ready := true.B
+        rdData := 0.U((conf.XLEN-8).W) ## uart.io.rdData.bits
+      }
+      is(1.U(3.W)) { //rdFlag
+        rdData := Cat(0.U(6.W), uart.io.rxFull)
+      }
+      is(2.U(3.W)) { //rdCnt
+        rdData := uart.io.rxCnt
+      }
+      is(4.U(3.W)) { //wrData
+        rdData := uart.io.txData.bits
+      }
+      is(5.U(3.W)) {
+        rdData := uart.io.txFull
+      }
+      is(6.U(3.W)) {
+        rdData := uart.io.txCnt
+      }
+    }
+  }
+
+  //Handle writes
+  uart.io.txData.bits := io.memIn.wdata(7,0)
+  uart.io.txData.valid := io.memIn.req && io.memIn.we && io.memIn.wmask(0)
+
+  //Handle I/O
+  io.memOut.ack := ack
+  io.memOut.rdata := rdData
+}
+
+object UartMain extends App {
+  (new chisel3.stage.ChiselStage).emitVerilog(new Uart(100_000_000, 115200, 2, 2), Array("--target-dir", "generated"))
+}
+

--- a/src/test/scala/core/ControlTransferSpec.scala
+++ b/src/test/scala/core/ControlTransferSpec.scala
@@ -25,7 +25,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |L2: nop
         |""".stripMargin
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 2, 15)
       expectReg(dut, 1, 8)
@@ -48,7 +48,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |""".stripMargin
 
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 1, 28)
       expectReg(dut, 2, 2)
@@ -75,7 +75,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |L2: nop
         |""".stripMargin
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 1, 12)
       expectReg(dut, 2, 15)
@@ -98,7 +98,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |L3: addi x5, x0 ,5
         |""".stripMargin
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 1, 32)
       expectReg(dut, 2, 2)
@@ -125,7 +125,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |""".stripMargin
 
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 2, 15)
       expectReg(dut, 3, 2)
@@ -149,7 +149,7 @@ class ControlTransferSpec extends AnyFlatSpec with ChiselScalatestTester with Ma
         |""".stripMargin
 
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       sh.run()
       expectReg(dut, 2, 15)
       expectReg(dut, 3, 30)

--- a/src/test/scala/core/CoreWrapperSpec.scala
+++ b/src/test/scala/core/CoreWrapperSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.must.Matchers
 class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Core wrapper"
 
-  it should "load a program that toggles LEDs" in {
+  ignore should "load a program that toggles LEDs" in {
     val wrapConf = scala.collection.immutable.HashMap(
       "numKeys" -> 16,
       "numLeds" -> 16,
@@ -32,7 +32,7 @@ class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matche
         |""".stripMargin
 
     //Each int of the program should be mapped to a seq of 4 bytes
-    val program = assemble(asm).flatMap { x =>
+    val program = assemble(asm, this.getTestName).flatMap { x =>
       Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
     }
 
@@ -46,7 +46,7 @@ class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matche
     }
   }
 
-  it should "execute a blink program" in {
+  ignore should "execute a blink program" in {
     val wrapConf = scala.collection.immutable.HashMap(
       "numKeys" -> 12,
       "numLeds" -> 12,
@@ -73,7 +73,7 @@ class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matche
         |j LOOP
         |""".stripMargin
 
-    val program = assemble(asm).flatMap { x =>
+    val program = assemble(asm, this.getTestName).flatMap { x =>
       Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
     }
     test(new CoreWrapper(wrapConf)(Config())).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
@@ -134,9 +134,9 @@ class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matche
         |.align(4) #Make sure a full byte is taken up
         |""".stripMargin
 
-    val program = assemble(asm).flatMap { x =>
+    val program = assemble(asm, this.getTestName).flatMap { x =>
       Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
-    }
+    }.toSeq
     test(new CoreWrapper(wrapConf)(Config())).withAnnotations(Seq(WriteVcdAnnotation, CachingAnnotation)) { dut =>
       //Write the instructions
       writeToUart(dut.io.uart.rx, dut.clock, wrapConf("coreFreq"), wrapConf("uartBaud"), program)

--- a/src/test/scala/core/CoreWrapperSpec.scala
+++ b/src/test/scala/core/CoreWrapperSpec.scala
@@ -1,0 +1,147 @@
+package core
+
+import chisel3._
+import chiseltest._
+import chiseltest.internal.CachingAnnotation
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class CoreWrapperSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Core wrapper"
+
+  it should "load a program that toggles LEDs" in {
+    val wrapConf = scala.collection.immutable.HashMap(
+      "numKeys" -> 16,
+      "numLeds" -> 16,
+      "coreFreq" -> 2,
+      "uartBaud" -> 1,
+      "uartRxBufSize" -> 2,
+      "uartTxBufSize" -> 2,
+      "uartBaseAddr" -> 0x01,
+      "ledsBaseAddr" -> 0x02,
+      "keysBaseAddr" -> 0x03,
+      "memSize" -> 128
+    )
+    val asm =
+      """
+        |li x1, 0xbeef
+        |li x2, 0x02000000
+        |sw x1, 0(x2)
+        |LOOP: addi x0, x0, 0
+        |j LOOP
+        |""".stripMargin
+
+    //Each int of the program should be mapped to a seq of 4 bytes
+    val program = assemble(asm).flatMap { x =>
+      Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
+    }
+
+    test(new CoreWrapper(wrapConf)(Config())).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      //Write the instructions
+      writeToUart(dut.io.uart.rx, dut.clock, 2, 1, program)
+      //Wait 50 cc, just because
+      dut.clock.step(50)
+      //Should see output on leds
+      dut.io.leds.expect(0xbeef)
+    }
+  }
+
+  it should "execute a blink program" in {
+    val wrapConf = scala.collection.immutable.HashMap(
+      "numKeys" -> 12,
+      "numLeds" -> 12,
+      "coreFreq" -> 10,
+      "uartBaud" -> 3,
+      "uartRxBufSize" -> 2,
+      "uartTxBufSize" -> 2,
+      "uartBaseAddr" -> 0x01,
+      "ledsBaseAddr" -> 0x02,
+      "keysBaseAddr" -> 0x03,
+      "memSize" -> 128
+    )
+    val asm =
+      """
+        |li x1, 0          # Blink value
+        |li x2, 0          # Counter value
+        |li x3, 10         #Max count value
+        |li x4, 0x02000000 #Address of LEDs
+        |LOOP: addi x2, x2, 1
+        |blt x2, x3, LOOP # count up
+        |addi x1, x1, 1
+        |sw x1, 0(x4)
+        |li x2, 0         # Reset counter
+        |j LOOP
+        |""".stripMargin
+
+    val program = assemble(asm).flatMap { x =>
+      Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
+    }
+    test(new CoreWrapper(wrapConf)(Config())).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      //Write the instructions
+      writeToUart(dut.io.uart.rx, dut.clock, wrapConf("coreFreq"), wrapConf("uartBaud"), program)
+      //Wait 200 cc, just because
+      dut.clock.step(200)
+      //Should see output on leds
+      assert(dut.io.leds.peekInt() != BigInt(0))
+    }
+  }
+
+  ignore should "write hello world on the UART" in {
+    val wrapConf = scala.collection.immutable.HashMap(
+      "numKeys" -> 12,
+      "numLeds" -> 12,
+      "coreFreq" -> 2,
+      "uartBaud" -> 1,
+      "uartRxBufSize" -> 2,
+      "uartTxBufSize" -> 2,
+      "uartBaseAddr" -> 0x01,
+      "ledsBaseAddr" -> 0x02,
+      "keysBaseAddr" -> 0x03,
+      "memSize" -> 512
+    )
+    val asm =
+      """
+        |.equ UART_BASE,    0x01000000
+        |.equ UART_TX,      0x01000010
+        |.equ UART_TX_FULL, 0x01000014
+        |.globl _start
+        |
+        |.text
+        |_start:
+        |la x1, HELLO_WORLD
+        |lb x2, 0(x1) #Initial fetch to simplify loop
+        |lui x3, %hi(UART_TX)
+        |addi x3, x3, %lo(UART_TX)
+        |lui x4, %hi(UART_TX_FULL)
+        |addi x4, x4, %lo(UART_TX_FULL)
+        |ECHO:
+        |beqz x2, PAUSE           #End of string
+        |addi x1, x1, 1          #incr char index
+        |CHECK_TX_FULL:
+        |lw x5, (x4)     #check if buffer is full
+        |bnez x5, CHECK_TX_FULL
+        |sb x2, (x3)          #write to UART
+        |j ECHO
+        |PAUSE: #end of string. Count up before going back
+        |li x1, 0
+        |li x2, 4000000
+        |PAUSE_LOOP: addi x1, x1, 1
+        |blt x1, x2, PAUSE_LOOP #count up
+        |j _start
+        |
+        |.data
+        |HELLO_WORLD: .string "Hello World!"
+        |.align(4) #Make sure a full byte is taken up
+        |""".stripMargin
+
+    val program = assemble(asm).flatMap { x =>
+      Seq(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF, (x >> 24) & 0xFF)
+    }
+    test(new CoreWrapper(wrapConf)(Config())).withAnnotations(Seq(WriteVcdAnnotation, CachingAnnotation)) { dut =>
+      //Write the instructions
+      writeToUart(dut.io.uart.rx, dut.clock, wrapConf("coreFreq"), wrapConf("uartBaud"), program)
+      //Wait 200 cc, just because
+      dut.clock.step(200)
+    }
+  }
+}

--- a/src/test/scala/core/DmemSpec.scala
+++ b/src/test/scala/core/DmemSpec.scala
@@ -27,7 +27,6 @@ class DmemSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
 
     test(new Core).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
       val imem = MemAgent(dut.io.imem, Icache(dut.io.imem, dut.clock, asm))
-      (assemble(asm) zip asm.split("\r\n")).zipWithIndex.foreach{case ((i,s),idx) => println(f"[${idx*4}%2d] $s: $i (${i.toHexString})")}
       val dmem = new MemAgent(dut.io.dmem)
       dmem.register(new DcacheWithDelay(dut.io.dmem, dut.clock, 0, 0xffff, 2, 4)())
       val sh = new SimulationHarness(dut, ListBuffer(imem, dmem))

--- a/src/test/scala/core/DmemSpec.scala
+++ b/src/test/scala/core/DmemSpec.scala
@@ -26,7 +26,9 @@ class DmemSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
          |""".stripMargin
 
     test(new Core).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
-      val imem = MemAgent(dut.io.imem, Icache(dut.io.imem, dut.clock, asm))
+
+      val imem = new MemAgent(dut.io.imem)
+      imem.register(new Icache(dut.io.imem, dut.clock, 0, 0xffff)(assembleMap(asm, this.getTestName)))
       val dmem = new MemAgent(dut.io.dmem)
       dmem.register(new DcacheWithDelay(dut.io.dmem, dut.clock, 0, 0xffff, 2, 4)())
       val sh = new SimulationHarness(dut, ListBuffer(imem, dmem))

--- a/src/test/scala/core/ImemSpec.scala
+++ b/src/test/scala/core/ImemSpec.scala
@@ -22,7 +22,7 @@ class ImemSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers{
 
     test(new Core).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       val imem = MemAgent(dut.io.imem, Seq(
-        new IcacheWithDelay(dut.io.imem, dut.clock, 0, 0xffff, 2, 4)(assembleMap(asm))
+        new IcacheWithDelay(dut.io.imem, dut.clock, 0, 0xffff, 2, 4)(assembleMap(asm, this.getTestName))
       ))
       val sh = new SimulationHarness(dut, ListBuffer(imem))
       sh.run()
@@ -48,7 +48,7 @@ class ImemSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers{
 
     test(new Core).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       val imem = MemAgent(dut.io.imem, Seq(
-        new IcacheWithDelay(dut.io.imem, dut.clock, 0, 0xffff, 2, 4)(assembleMap(asm))
+        new IcacheWithDelay(dut.io.imem, dut.clock, 0, 0xffff, 2, 4)(assembleMap(asm, this.getTestName))
       ))
       val sh = new SimulationHarness(dut, ListBuffer(imem))
       sh.run()

--- a/src/test/scala/core/ImmediateInstructionSpec.scala
+++ b/src/test/scala/core/ImmediateInstructionSpec.scala
@@ -175,7 +175,7 @@ class ImmediateInstructionSpec extends AnyFlatSpec with ChiselScalatestTester wi
     test(new Core()) {dut =>
       testFun(dut, 50, inst)
       for(i <- 0 until 30) {
-        expectReg(dut, i+1, ui(i) + 4*i, s"Expecting ${ui(i)+4*i} for pc=${4*i} and immediate ${ui(i)} in reg x${i+1}")
+        expectReg(dut, i+1, ui(i) + 4*i)
       }
     }
   }

--- a/src/test/scala/core/ImmediateInstructionSpec.scala
+++ b/src/test/scala/core/ImmediateInstructionSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable.ListBuffer
 
 class ImmediateInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
   behavior of "I-type instruction"
-  
+
   implicit val conf: Config = defaultConf
 
   /**
@@ -33,7 +33,6 @@ class ImmediateInstructionSpec extends AnyFlatSpec with ChiselScalatestTester wi
     }
     for(i <- 17 until 32) {
       r(i) = op(r(i-16), lb(i-2).asInstanceOf[ItypeInstruction].imm.litValue.toInt)
-      println(f"x${i}, v1=${r(i-16)}, v2=${lb(i-2).asInstanceOf[ItypeInstruction].imm.litValue.toInt}, res=${r(i)}")
     }
     r
   }
@@ -176,8 +175,7 @@ class ImmediateInstructionSpec extends AnyFlatSpec with ChiselScalatestTester wi
     test(new Core()) {dut =>
       testFun(dut, 50, inst)
       for(i <- 0 until 30) {
-        println(s"Expecting ${ui(i)+4*i} for pc=${4*i} and immediate ${ui(i)} in reg x${i+1}")
-        expectReg(dut, i+1, ui(i) + 4*i)
+        expectReg(dut, i+1, ui(i) + 4*i, s"Expecting ${ui(i)+4*i} for pc=${4*i} and immediate ${ui(i)} in reg x${i+1}")
       }
     }
   }

--- a/src/test/scala/core/RtypeInstructionSpec.scala
+++ b/src/test/scala/core/RtypeInstructionSpec.scala
@@ -34,7 +34,6 @@ class RtypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
     }
     for(i <- 17 until 32) {
       r(i) = op(r(i-16), r(i-15))
-      println(f"x${i}, v1=${r(i-16)}, v2=${r(i-15)}, res=${r(i)}")
     }
     r
   }

--- a/src/test/scala/core/SimpleProgramsSpec.scala
+++ b/src/test/scala/core/SimpleProgramsSpec.scala
@@ -28,7 +28,7 @@ class SimpleProgramsSpec extends AnyFlatSpec with ChiselScalatestTester with Mat
 
 
     test(new Core) {dut =>
-      val sh = SimulationHarness(dut, assembleMap(asm))
+      val sh = SimulationHarness(dut, assembleMap(asm, this.getTestName))
       //Each loop of add,addi,blt takes 5 clock cycles since branches are always mispredicted and pipeline must be flushed
       sh.setTimeout(600)
       sh.run()
@@ -79,7 +79,7 @@ class SimpleProgramsSpec extends AnyFlatSpec with ChiselScalatestTester with Mat
         |""".stripMargin
 
     test(new Core) { dut =>
-      val imem = MemAgent(dut.io.imem, Icache(dut.io.imem, dut.clock, assembleMap(asm)))
+      val imem = MemAgent(dut.io.imem, Icache(dut.io.imem, dut.clock, assembleMap(asm, this.getTestName)))
       val dmem = MemAgent(dut.io.dmem, Seq(new Dcache(dut.io.dmem, dut.clock, 0, 0xffff)()))
       dmem.register(new SoftwareSerialPort(dut.io.dmem, dut.clock, 0x10000, 0x10000))
 

--- a/src/test/scala/core/SimpleProgramsSpec.scala
+++ b/src/test/scala/core/SimpleProgramsSpec.scala
@@ -14,6 +14,7 @@ class SimpleProgramsSpec extends AnyFlatSpec with ChiselScalatestTester with Mat
   it should "compute the sum of 1..100" in {
     val asm =
       """
+        |_start:
         |addi x1, x0, 1
         |add x2, x0, x0
         |addi x3, x0, 101
@@ -44,6 +45,7 @@ class SimpleProgramsSpec extends AnyFlatSpec with ChiselScalatestTester with Mat
   it should "write Hello World to serial output" in {
     val asm =
       """
+        |_start:
         |addi x1, x0, 72
         |addi x2, x0, 101
         |addi x3, x0, 108

--- a/src/test/scala/core/StypeInstructionSpec.scala
+++ b/src/test/scala/core/StypeInstructionSpec.scala
@@ -2,13 +2,21 @@ package core
 
 import chisel3._
 import chiseltest._
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 
-class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+import java.io.File
+
+class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers with BeforeAndAfterEach {
   behavior of "Memory instructions"
   
   implicit val conf: Config = defaultConf
+
+//  override def afterEach() = {
+//    val f = new File(s"${this.getTestName}.bin")
+//    f.del
+//  }
 
   it should "perform a SW/LW" in {
     val asm =
@@ -17,7 +25,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         |sw x1, 20(x0)
         |lw x2, 20(x0)
         |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -33,7 +41,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
       |sh x1, 20(x0)
       |lh x2, 20(x0)
       |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) { dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -49,7 +57,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
       |sb x1, 20(x0)
       |lb x2, 20(x0)
       |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) { dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -69,7 +77,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         | lb x3, 0(x0)
         | lb x4, 4(x0)
         |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) { dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -91,7 +99,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         | lbu x3, 0(x0)
         | lbu x4, 4(x0)
         | """.stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -113,7 +121,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         | lh x3, 0(x0)
         | lh x4, 4(x0)
         | """.stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -135,7 +143,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         | lhu x3, 0(x0)
         | lhu x4, 4(x0)
         | """.stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -161,7 +169,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         |lbu x8, 2(x0)
         |lbu x9, 3(x0)
         |""".stripMargin
-    val instr = assembleMap(asm)
+    val instr = assembleMap(asm, this.getTestName)
     test(new Core()) {dut =>
       val sh = SimulationHarness(dut, instr)
       sh.run()
@@ -194,7 +202,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         |sb x5, 3(x0)
         |lw x6, 0(x0)
         |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core()) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -225,7 +233,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         |lw x6, 0(x0)
         |lw x7, 4(x0)
         |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()
@@ -257,7 +265,7 @@ class StypeInstructionSpec extends AnyFlatSpec with ChiselScalatestTester with M
         |addi x2, x2, 5
         |addi x3, x0, 10
         |""".stripMargin
-    val instrs = assembleMap(asm)
+    val instrs = assembleMap(asm, this.getTestName)
     test(new Core).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
       val sh = SimulationHarness(dut, instrs)
       sh.run()

--- a/src/test/scala/core/modules/ImmediateGeneratorSpec.scala
+++ b/src/test/scala/core/modules/ImmediateGeneratorSpec.scala
@@ -23,12 +23,9 @@ class ImmediateGeneratorSpec extends AnyFlatSpec with ChiselScalatestTester with
   def testFun(dut: ImmediateGenerator, imm: => Int, m: Int => Instruction): Unit = {
     for(_ <- 0 until 10) {
       val i = imm
-      println(f"Poking immediate $i")
       val inst = m(i)
-      println(f"Instruction is $inst / ${inst.toUInt}")
       dut.io.instr.poke(inst.toUInt)
       dut.clock.step()
-      println(f"Peeking immediate ${dut.io.imm.peek()}")
       dut.io.imm.expect(i.toLong & 0xffff_ffffL)
       dut.clock.step()
     }

--- a/src/test/scala/core/package.scala
+++ b/src/test/scala/core/package.scala
@@ -25,8 +25,8 @@ package object core {
     bw.close()
 
     //Compile and extract .text-segment
-    val gccOpts = s"-nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -T programs/linker.ld  $file.s -o $file.o"
-    val objcopyOpts = s"-R \".note.gnu.build-id\" -O binary $file.o $file.bin"
+    val gccOpts = s"-nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -T programs/linker.ld -Wl,--no-relax $file.s -o $file.o"
+    val objcopyOpts = s"-O binary $file.o $file.bin"
     val (gcc, objcopy) = if (System.getProperty("os.name").contains("Windows")) {
       ("riscv64-unknown-elf-gcc.exe", "riscv64-unknown-elf-objcopy.exe")
     } else {
@@ -42,7 +42,7 @@ package object core {
 //      s"riscv64-linux-gnu-objcopy -O binary $file.o $file.bin".!
 //    }
 
-    //Retrieve .text-segment, parse as int
+    //Retrieve .text and .data-segments, parse as int
     val fis = new FileInputStream(s"$file.bin")
     val bytes = fis.readAllBytes()
     fis.close()

--- a/src/test/scala/core/package.scala
+++ b/src/test/scala/core/package.scala
@@ -25,7 +25,7 @@ package object core {
     bw.close()
 
     //Compile and extract .text-segment
-    val gccOpts = s"-nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -T programs/linker.ld -Wl,--no-relax $file.s -o $file.o"
+    val gccOpts = s"-nostdlib -nostartfiles -march=rv32i -mabi=ilp32 -c $file.s -o $file.o"
     val objcopyOpts = s"-O binary $file.o $file.bin"
     val (gcc, objcopy) = if (System.getProperty("os.name").contains("Windows")) {
       ("riscv64-unknown-elf-gcc.exe", "riscv64-unknown-elf-objcopy.exe")
@@ -438,11 +438,11 @@ package object core {
     buf.zipWithIndex.map { case (instr,i) => (i*4, instr) }.toMap
   }
 
-  def expectReg(dut: Core, i: Int, v: Int): Unit = {
+  def expectReg(dut: Core, i: Int, v: Int, msg: String = ""): Unit = {
     expectReg(dut, i, v.toLong & 0xffffffffL)
   }
 
-  def expectReg(dut: Core, i: Int, v: Long): Unit = {
-    dut.io.dbg.get.reg(i).expect(v.U)
+  def expectReg(dut: Core, i: Int, v: Long, msg: String = ""): Unit = {
+    dut.io.dbg.get.reg(i).expect(v.U, msg)
   }
 }

--- a/src/test/scala/peripherals/HWBootloaderSpec.scala
+++ b/src/test/scala/peripherals/HWBootloaderSpec.scala
@@ -1,0 +1,151 @@
+package peripherals
+
+import chisel3._
+import scala.collection.mutable
+import chisel3.util.OHToUInt
+import chiseltest._
+import core.Config
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class HWBootloaderSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers{
+  behavior of "Hardware bootloader"
+
+  implicit val conf: Config = Config()
+
+  /*
+  3 behaviours:
+  - first iteration, numBytes < 255, should go straight to GO
+  - first iteration, numBytes == 255, should wait for more
+  - n'th iteration, numBytes == 255. n+1'th iteration, numBytes < 255, should GO
+   */
+
+  /**
+   * Write a value onto the UART receiver
+   * @param freq Uart core frequency
+   * @param baud Uart baud rate
+   * @param value Value to write out. Must in range 0x00 - 0xff
+   * @param rxd Uart rxd pin
+   * @param clock DUT clock signal
+   */
+  def writeToUart(dut: HWBootloader, value: Int): Unit = {
+    //All writes to UART are double-registered. Should wait +2 cc afterwards before we can expect output
+    val cyclesPerBaud = dut.frequency/dut.baudRate
+    val txData = 0x600 | ((value & 0xFF) << 1) | 0
+    for(i <- 0 until 11) {
+      val tx = (txData >> i) & 1
+      dut.io.rxd.poke(tx.B)
+      dut.clock.step(cyclesPerBaud)
+    }
+    dut.io.rxd.poke(true.B)
+  }
+
+  /**
+   * Read a value coming off the memory bus, storing it into the passed map
+   * @param mem Mutable map to store all received bytes and their address
+   * @param dut The DUT
+   * @param go Array holding received go-signal, to indicate when testing is finished
+   */
+  def readFromMem(mem: mutable.Map[Int, Byte], dut: HWBootloader, go: Array[Boolean]): Unit = {
+    while(!go(0)) {
+      while(!dut.io.memOut.req.peekBoolean() && !go(0)) {
+        dut.clock.step()
+      }
+      if (go(0)) {
+        return
+      }
+      val offset = dut.io.memOut.wmask.peekInt().toInt match {
+        case 1 => 0
+        case 2 => 1
+        case 4 => 2
+        case 8 => 3
+        case _ => fail(s"offset was not decodeable from one-hot, was ${dut.io.memOut.wmask.peek()}")
+      }
+      val addr = (dut.io.memOut.addr.peekInt() + offset).toInt
+      mem.update(addr, dut.io.memOut.wdata.peekInt().toByte)
+      dut.clock.step()
+      timescope {
+        dut.io.memIn.ack.poke(true.B)
+        dut.clock.step()
+      }
+    }
+  }
+
+  /**
+   * Do the HW Bootloader test. Transmits a number of bytes onto the UART receiver, then samples these
+   * off the memory output channel
+   * @param dut The DUT
+   * @param bytes The bytes to write onto the UART receiver
+   * @return
+   */
+  def doHWBootloader(dut: HWBootloader, bytes: Seq[Byte]): mutable.Map[Int, Byte] = {
+    val go = Array(x = false) //Using array for go to pass into readFromMem
+    val mem = scala.collection.mutable.Map[Int, Byte]()
+    fork {
+      for(bp <- bytes.grouped(255)) {
+        //Number of bytes coming
+        writeToUart(dut, bp.length)
+        //Following bytes
+        bp.foreach(b => writeToUart(dut, b))
+      }
+      //If exactly a multiple of 255, should send 0 afterwards to move into GO state
+      if (bytes.length % 255 == 0) {
+        writeToUart(dut, 0)
+      }
+      while(!go(0)) {
+        dut.clock.step()
+      }
+    } .fork {
+      readFromMem(mem, dut, go)
+    } .fork {
+      while(!dut.io.go.peekBoolean()) {
+        dut.clock.step()
+      }
+      go(0) = true
+    } .joinAndStep(dut.clock)
+    mem
+  }
+
+  it should "accept 2 bytes and then activate GO" in {
+    test(new HWBootloader(2, 1, 1, 1)).withAnnotations(Seq(WriteVcdAnnotation)) { dut =>
+      val mem = doHWBootloader(dut, Seq(0xab, 0x3f).map(_.toByte))
+      assert(mem(0) == 0xab.toByte)
+      assert(mem(1) == 0x3f.toByte)
+    }
+  }
+
+  it should "accept more than 255 bytes and then activate GO" in {
+    test(new HWBootloader(2, 1, 1, 1)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.clock.setTimeout(5000)
+      val n = scala.util.Random.nextInt(253) + 256
+      val wdata = scala.util.Random.nextBytes(n).toSeq
+      val mem = doHWBootloader(dut, wdata)
+      for ((v,i) <- wdata.zipWithIndex) {
+        assert(mem(i) == v, f"Mem[$i] was not $v as expected, was ${mem(i)}")
+      }
+    }
+  }
+
+  it should "accept more than 2 full packets and then activate GO" in {
+    test(new HWBootloader(2, 1, 1, 1)) { dut =>
+      dut.clock.setTimeout(5000)
+      val n = scala.util.Random.nextInt(70) + 530
+      val wdata = scala.util.Random.nextBytes(n).toSeq
+      val mem = doHWBootloader(dut, wdata)
+      for ((v,i) <- wdata.zipWithIndex) {
+        assert(mem(i) == v, f"Mem[$i] was not $v as expected, was ${mem(i)}")
+      }
+    }
+  }
+
+  it should "accept exactly 255 bytes and then activate GO" in {
+    test(new HWBootloader(2, 1, 1, 1)).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      dut.clock.setTimeout(5000)
+      val wdata = scala.util.Random.nextBytes(255).toSeq
+      val mem = doHWBootloader(dut, wdata)
+      for ((v,i) <- wdata.zipWithIndex) {
+        assert(mem(i) == v, f"Mem[$i] was not $v as expected, was ${mem(i)}")
+      }
+    }
+  }
+}

--- a/src/test/scala/peripherals/HWBootloaderSpec.scala
+++ b/src/test/scala/peripherals/HWBootloaderSpec.scala
@@ -48,24 +48,24 @@ class HWBootloaderSpec extends AnyFlatSpec with ChiselScalatestTester with Match
    */
   def readFromMem(mem: mutable.Map[Int, Byte], dut: HWBootloader, go: Array[Boolean]): Unit = {
     while(!go(0)) {
-      while(!dut.io.memOut.req.peekBoolean() && !go(0)) {
+      while(!dut.io.mem.req.req.peekBoolean() && !go(0)) {
         dut.clock.step()
       }
       if (go(0)) {
         return
       }
-      val offset = dut.io.memOut.wmask.peekInt().toInt match {
+      val offset = dut.io.mem.req.wmask.peekInt().toInt match {
         case 1 => 0
         case 2 => 1
         case 4 => 2
         case 8 => 3
-        case _ => fail(s"offset was not decodeable from one-hot, was ${dut.io.memOut.wmask.peek()}")
+        case _ => fail(s"offset was not decodeable from one-hot, was ${dut.io.mem.req.wmask.peek()}")
       }
-      val addr = (dut.io.memOut.addr.peekInt() + offset).toInt
-      mem.update(addr, dut.io.memOut.wdata.peekInt().toByte)
+      val addr = (dut.io.mem.req.addr.peekInt() + offset).toInt
+      mem.update(addr, dut.io.mem.req.wdata.peekInt().toByte)
       dut.clock.step()
       timescope {
-        dut.io.memIn.ack.poke(true.B)
+        dut.io.mem.resp.ack.poke(true.B)
         dut.clock.step()
       }
     }

--- a/src/test/scala/peripherals/MemArbiterSpec.scala
+++ b/src/test/scala/peripherals/MemArbiterSpec.scala
@@ -1,0 +1,56 @@
+package peripherals
+
+import chisel3._
+import chiseltest._
+import core.Config
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class MemArbiterSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Memory arbiter"
+
+  it should "always forward the correct memory port" in {
+    test(new MemArbiter(3, Seq(0x01, 0x02, 0x03))(Config())).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      val p = dut.io.periph
+      val m = dut.io.master
+      val N = 3
+      for(i <- 0 until N) {
+        p(i).resp.rdata.poke((i+1) * 100)
+      }
+      //Test connection to no peripheral
+      //None should have req or data forwarded
+      m.req.req.poke(true)
+      m.req.addr.poke(0)
+      m.req.wdata.poke(50)
+      for(_ <- 0 until 3) {
+        p.foreach{p =>
+          p.req.req.expect(false)
+          p.req.wdata.expect(0)
+        }
+        dut.clock.step()
+      }
+      m.req.req.poke(false.B)
+      dut.clock.step(2)
+      m.req.req.poke(true.B)
+
+      //Test connection to each peripheral in turn
+      for(i <- 0 until N) {
+        m.req.addr.poke((i+1) << 24)
+        for(j <- 0 until N) {
+          p(j).req.req.expect(i == j, f"i=$i, j=$j")
+          p(j).req.wdata.expect(if (i == j) 50 else 0, s"i=$i, j=$j")
+        }
+        dut.clock.step()
+        //Now, rdata should be correctly forwarded from the attached peripheral the master
+        for (_ <- 0 until 5) { //Num clock cycles, just to test over multiple CC
+          for(j <- 0 until N) {
+            p(j).req.req.expect(i == j, f"i=$i, j=$j")
+            p(j).req.wdata.expect(if (i == j) 50 else 0, s"i=$i, j=$j")
+            m.resp.rdata.expect((i+1)*100, s"i=$i, j=$j")
+          }
+          dut.clock.step()
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/peripherals/MemBlockSpec.scala
+++ b/src/test/scala/peripherals/MemBlockSpec.scala
@@ -1,0 +1,119 @@
+package peripherals
+
+import chisel3._
+import chiseltest._
+import core.Config
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class MemBlockSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Memory block"
+
+  it should "support full word writes and reads" in {
+    test(new MemBlock(8)(Config())).withAnnotations(Seq(WriteVcdAnnotation)) {dut =>
+      val req = dut.io.req
+      val resp = dut.io.resp
+
+      req.req.poke(false.B)
+      dut.clock.step(3)
+
+      req.req.poke(true.B)
+      req.addr.poke(0x0)
+      req.wdata.poke(0x12345678)
+      req.wmask.poke(0xf)
+      req.we.poke(true.B)
+      dut.clock.step()
+
+      resp.ack.expect(true.B)
+      req.we.poke(false.B)
+      dut.clock.step()
+
+      resp.ack.expect(true.B)
+      resp.rdata.expect(0x12345678)
+    }
+  }
+
+  it should "support half word writes" in {
+    test(new MemBlock(8)(Config())) {dut =>
+      //Write some initial data
+      val req = dut.io.req
+      val resp = dut.io.resp
+
+      req.req.poke(false.B)
+      dut.clock.step(3)
+
+      req.req.poke(true.B)
+      req.addr.poke(0x0)
+      req.wdata.poke(0x12345678L)
+      req.wmask.poke(0xf)
+      req.we.poke(true.B)
+      dut.clock.step()
+
+      resp.ack.expect(true.B)
+      req.addr.poke(0x4)
+      req.wdata.poke(0x9abcdef0L)
+      dut.clock.step()
+
+      //Perform a half-word write to the LSB of address 0
+      resp.ack.expect(true.B)
+      req.addr.poke(0)
+      req.wdata.poke(0xabcdabcdL)
+      req.wmask.poke(0x3)
+      dut.clock.step()
+
+      resp.ack.expect(true.B)
+      req.wdata.poke(0xfecdfecdL)
+      req.wmask.poke(0xc) //1100
+      dut.clock.step()
+
+      //Read back the data
+      req.we.poke(false.B)
+      resp.ack.expect(true.B)
+      dut.clock.step()
+
+      resp.ack.expect(true.B)
+      resp.rdata.expect(0xfecdabcdL)
+    }
+  }
+
+  it should "support byte writes" in {
+    test(new MemBlock(8)(Config())) { dut =>
+      //Write some initial data
+      val req = dut.io.req
+      val resp = dut.io.resp
+
+      req.req.poke(false.B)
+      dut.clock.step(3)
+
+      req.req.poke(true.B)
+      req.addr.poke(0x0)
+      req.wdata.poke(0x12345678L)
+      req.wmask.poke(0xf)
+      req.we.poke(true.B)
+      dut.clock.step()
+
+      req.wdata.poke(0xababababL)
+      req.wmask.poke(0x1)
+      dut.clock.step()
+
+      req.wdata.poke(0x0e0e0e0eL)
+      req.wmask.poke(0x1 << 1)
+      dut.clock.step()
+
+      req.wdata.poke(0x86868686L)
+      req.wmask.poke(0x1 << 2)
+      dut.clock.step()
+
+      req.wdata.poke(0xc3c3c3c3L)
+      req.wmask.poke(0x1 << 3)
+      dut.clock.step()
+
+      //Read back our data
+      req.we.poke(false.B)
+      dut.clock.step()
+
+      resp.ack.expect(true)
+      resp.rdata.expect(0xc3860eabL)
+    }
+  }
+}

--- a/src/test/scala/peripherals/MemMuxSpec.scala
+++ b/src/test/scala/peripherals/MemMuxSpec.scala
@@ -1,0 +1,140 @@
+package peripherals
+
+import chisel3._
+import chiseltest._
+import core.Config
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+class MemMuxSpec extends AnyFlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Memory mux"
+
+  it should "forward DMEM req and block IMEM req while waiting" in {
+    test(new MemMux()(Config())) {dut =>
+      dut.io.dmem.req.req.poke(true)
+
+      dut.io.dmem.req.addr.poke(30)
+      dut.io.dmem.req.wdata.poke(40)
+      dut.io.imem.req.addr.poke(130)
+      dut.io.imem.req.wdata.poke(140)
+
+      dut.io.mem.req.req.expect(true)
+      dut.io.mem.req.addr.expect(30)
+      dut.io.mem.req.wdata.expect(40)
+
+      dut.clock.step()
+      //Taking IMEM req high now should not let it propagate
+      dut.io.imem.req.req.poke(true)
+
+      for(_ <- 0 until 5) {
+        dut.io.mem.req.req.expect(true)
+        dut.io.mem.req.addr.expect(30)
+        dut.io.mem.req.wdata.expect(40)
+        dut.clock.step()
+      }
+
+      //Taking ack high should only forward it to dmem
+      dut.io.mem.resp.ack.poke(true)
+      dut.io.mem.resp.rdata.poke(300)
+
+      dut.io.dmem.resp.ack.expect(true)
+      dut.io.dmem.resp.rdata.expect(300)
+      dut.io.imem.resp.ack.expect(false)
+      dut.io.imem.resp.rdata.expect(300)
+    }
+  }
+
+  it should "forward IMEM req and block DMEM req while waiting" in {
+    test(new MemMux()(Config())) {dut =>
+      dut.io.imem.req.req.poke(true)
+      dut.io.dmem.req.req.poke(false)
+
+      dut.io.imem.req.addr.poke(30)
+      dut.io.imem.req.wdata.poke(40)
+      dut.io.dmem.req.addr.poke(130)
+      dut.io.dmem.req.wdata.poke(140)
+
+      dut.io.mem.req.req.expect(true)
+      dut.io.mem.req.addr.expect(30)
+      dut.io.mem.req.wdata.expect(40)
+
+      dut.clock.step()
+      //Taking IMEM req high now should not let it propagate
+      dut.io.dmem.req.req.poke(true)
+
+      for(_ <- 0 until 5) {
+        dut.io.mem.req.req.expect(true)
+        dut.io.mem.req.addr.expect(30)
+        dut.io.mem.req.wdata.expect(40)
+        dut.clock.step()
+      }
+
+      //Taking ack high should only forward it to dmem
+      dut.io.mem.resp.ack.poke(true)
+      dut.io.mem.resp.rdata.poke(300)
+
+      dut.io.dmem.resp.ack.expect(false)
+      dut.io.dmem.resp.rdata.expect(300)
+      dut.io.imem.resp.ack.expect(true)
+      dut.io.imem.resp.rdata.expect(300)
+    }
+  }
+
+  it should "prioritize DMEM over IMEM when both req at the same time" in {
+    test(new MemMux()(Config())) {dut =>
+      dut.io.imem.req.req.poke(true)
+      dut.io.dmem.req.req.poke(true)
+
+      dut.io.imem.req.addr.poke(30)
+      dut.io.imem.req.wdata.poke(40)
+      dut.io.dmem.req.addr.poke(130)
+      dut.io.dmem.req.wdata.poke(140)
+
+      dut.io.mem.req.req.expect(true)
+      dut.io.mem.req.addr.expect(130)
+      dut.io.mem.req.wdata.expect(140)
+
+      dut.clock.step()
+      dut.io.mem.req.req.expect(true)
+      dut.io.mem.req.addr.expect(130)
+      dut.io.mem.req.wdata.expect(140)
+
+      dut.io.mem.resp.ack.poke(true)
+      dut.io.dmem.resp.ack.expect(true)
+      dut.io.imem.resp.ack.expect(false)
+    }
+  }
+
+  it should "prioritize DMEM over IMEM when IMEM is acknowledging" in {
+    test(new MemMux()(Config())) {dut =>
+      //Set up connection from IMEM->MEM
+      dut.io.imem.req.req.poke(true.B)
+      dut.io.imem.req.addr.poke(100)
+      dut.io.mem.req.addr.expect(100)
+
+      //IMEM request not yet acknowledged, DMEM request activated
+      dut.clock.step()
+      dut.io.dmem.req.req.poke(true)
+      dut.io.dmem.req.addr.poke(42)
+      dut.io.dmem.req.wdata.poke(84)
+
+      dut.io.mem.req.addr.expect(100)
+
+      //Acknowledge IMEM request, should now forward DMEM request
+      dut.clock.step()
+      dut.io.mem.resp.ack.poke(true)
+      dut.io.mem.resp.rdata.poke(100)
+
+      dut.io.imem.resp.ack.expect(true)
+      dut.io.dmem.resp.ack.expect(false)
+      dut.io.imem.resp.rdata.expect(100)
+      dut.io.mem.req.addr.expect(42)
+      dut.io.mem.req.wdata.expect(84)
+
+      dut.clock.step()
+      dut.io.dmem.resp.ack.expect(true)
+      dut.io.imem.resp.ack.expect(false)
+      dut.io.dmem.resp.rdata.expect(100)
+    }
+  }
+}

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -1,0 +1,28 @@
+import serial
+import sys
+
+def do_download():
+  print(sys.argv)
+  with open(f"programs/{sys.argv[2]}.bin", "rb") as f:
+    port = sys.argv[1]
+    print(f"Opening serial port {port}")
+    ser = serial.Serial(port, 115200, timeout=1)
+    tx = f.read()
+    bundles = [tx[i:i+255] for i in range(0, len(tx), 255)]
+    for bnd in bundles:
+      ser.write(bytes([len(bnd)]))
+      ser.write(bnd)
+      print(len(bnd))
+      print(bnd)
+      print()
+
+    if (len(bundles[-1]) == 255): #If last bundle was a full block, send 0 to activate go
+      ser.write(bytes([0]))
+      print("Wrote 0 for last block")
+    print("Finished writing data")
+    print(f"Data from OS UART buffer: {ser.read_all()}")
+  # port = serial.Serial(sys.argv[1], 115200, timeout=1)
+  # print(port.read(8))
+
+if __name__ == "__main__":
+  do_download()


### PR DESCRIPTION
Adds the `CoreWrapper` class that wraps the core with a number of useful peripherals (UART, Keys and LEDs). 
Also adds a linker script and Makefile targets to more easily compile programs and download these onto the system.